### PR TITLE
App launched from history now correctly displays MainFragment

### DIFF
--- a/app/src/main/java/me/worric/souvenarius/ui/common/NavigationUtils.java
+++ b/app/src/main/java/me/worric/souvenarius/ui/common/NavigationUtils.java
@@ -1,0 +1,39 @@
+package me.worric.souvenarius.ui.common;
+
+import android.content.Intent;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+
+import me.worric.souvenarius.R;
+import me.worric.souvenarius.ui.main.MainFragment;
+
+public final class NavigationUtils {
+
+    public static final int LAUNCHED_FROM_HISTORY_AND_IN_NEW_TASK = Intent.FLAG_ACTIVITY_NEW_TASK |
+            Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY;
+
+    private NavigationUtils() {
+    }
+
+    public static void buildCustomFragmentNavigation(FragmentManager fm, Fragment customFragment) {
+        fm.beginTransaction()
+                .replace(R.id.fragment_container, customFragment)
+                .setReorderingAllowed(true)
+                .addToBackStack(null)
+                .commit();
+    }
+
+    public static void buildMainFragmentNavigation(FragmentManager fm) {
+        fm.beginTransaction()
+                .add(R.id.fragment_container, MainFragment.newInstance())
+                .setReorderingAllowed(true)
+                .commit();
+    }
+
+    public static void normalLaunch(FragmentManager fm) {
+        fm.beginTransaction()
+                .add(R.id.fragment_container, MainFragment.newInstance())
+                .commit();
+    }
+
+}


### PR DESCRIPTION
This PR addresses the bug encountered when:

1. The app has been launched through the widget (particular Intent actions)
2. The app has been closed by using the back button from the main screen
3. The app is brought back up through the Recent screen

Under these circumstances, the app would consume the action in the old Intent and display the corresponding fragment (i.e. AddFragment or DetailFragment), even though the app picture in the Recent screen correctly showed the MainFragment from when it was closed.

Now a check has been added for this case by checking the Intent flags passed along via the Intent.