### PR TITLE
Fix icon and label length in DetailFragment

### DIFF
--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -51,7 +51,7 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 android:textStyle="italic"
                 android:text="@{@string/num_photos_detail(currentSouvenir.photos.size)}"
-                android:drawableStart="@drawable/ic_photo"
+                android:drawableStart="@drawable/ic_photo_detail"
                 android:drawablePadding="2dp"
                 android:gravity="center_vertical"
                 tools:text="Photos: 2" />
@@ -80,12 +80,11 @@
 
             <TextView
                 android:id="@+id/tv_detail_label_title"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 app:layout_constraintTop_toBottomOf="@+id/barrier_photos_timestamp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
                 android:textAppearance="@style/TextAppearance.AppCompat.Small"
                 android:fontFamily="sans-serif-condensed"
                 android:drawableStart="@drawable/ic_edit_detail"
@@ -111,12 +110,11 @@
 
             <TextView
                 android:id="@+id/tv_detail_label_place"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 app:layout_constraintTop_toBottomOf="@+id/tv_detail_title"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
                 android:fontFamily="sans-serif-condensed"
                 android:drawableStart="@drawable/ic_edit_detail"
                 android:drawablePadding="2dp"
@@ -142,12 +140,11 @@
 
             <TextView
                 android:id="@+id/tv_detail_label_story"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 app:layout_constraintTop_toBottomOf="@+id/tv_detail_place"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
                 android:text="@string/label_story_detail"
                 android:fontFamily="sans-serif-condensed"
                 android:drawableStart="@drawable/ic_edit_detail"


### PR DESCRIPTION
#### This PR fixes small changes in the DetailFragment layout

- Label length is adjusted to `wrap_content` and the constraints changed to anchor to start of `parent` instead of both start and end. Otherwise, the screen could not be scrolled when trying to drag but hitting the label `TextView`s
- Photo icon had the wrong color