### PR TITLE
Update SDK -> 28. Externalize dep versions.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,11 +9,11 @@ android {
             storePassword 'souvenarius'
         }
     }
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "me.worric.souvenarius"
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -37,16 +37,19 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Support libraries
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:cardview-v7:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:cardview-v7:$supportLibVersion"
+    implementation "com.android.support:recyclerview-v7:$supportLibVersion"
+    implementation "com.android.support:design:$supportLibVersion"
+    implementation "com.android.support.constraint:constraint-layout:$constVersion"
+    // Resolve dependency conflicts
+    implementation "com.android.support:support-v4:$supportLibVersion"
+    implementation "com.android.support:customtabs:$supportLibVersion"
     // Architecture Components
-    implementation 'android.arch.lifecycle:extensions:1.1.1'
-    implementation 'android.arch.lifecycle:common-java8:1.1.1'
-    implementation 'android.arch.persistence.room:runtime:1.1.1'
-    annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
+    implementation "android.arch.lifecycle:extensions:$archVersion"
+    implementation "android.arch.lifecycle:common-java8:$archVersion"
+    implementation "android.arch.persistence.room:runtime:$archVersion"
+    annotationProcessor "android.arch.persistence.room:compiler:$archVersion"
     // Firebase & Google services
     implementation 'com.firebaseui:firebase-ui-auth:4.1.0'
     implementation 'com.firebaseui:firebase-ui-storage:4.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,12 @@ allprojects {
     }
 }
 
+ext {
+    supportLibVersion = '28.0.0-rc02'
+    constVersion = '1.1.2'
+    archVersion = '1.1.1'
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
This PR updates the SDK version to 28 as well as updates support library versions accordingly (28.0.0-rc02). Furthermore, versions strings are centralized by placing them in the Gradle `rootProject`.