### PR TITLE
Use View LifecycleOwner

### DIFF
--- a/app/src/main/java/me/worric/souvenarius/ui/detail/DetailFragment.java
+++ b/app/src/main/java/me/worric/souvenarius/ui/detail/DetailFragment.java
@@ -83,7 +83,7 @@ public class DetailFragment extends Fragment {
         String souvenirId = getArguments().getString(KEY_SOUVENIR_ID);
         mViewModel = ViewModelProviders.of(this, mFactory).get(DetailViewModel.class);
         mViewModel.setSouvenirId(souvenirId);
-        mViewModel.getCurrentSouvenir().observe(this, souvenir -> {
+        mViewModel.getCurrentSouvenir().observe(getViewLifecycleOwner(), souvenir -> {
             mAdapter.swapPhotos(souvenir);
             mBinding.setCurrentSouvenir(souvenir);
             restoreLayoutManagerState(savedInstanceState);
@@ -134,12 +134,6 @@ public class DetailFragment extends Fragment {
         mLayoutManagerState = mBinding.rvSouvenirPhotoList.getLayoutManager().onSaveInstanceState();
         mScrollViewPosition = new int[]{mBinding.svDetailRoot.getScrollX(),
                 mBinding.svDetailRoot.getScrollY()};
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        mViewModel.getCurrentSouvenir().removeObservers(this);
     }
 
     @Override

--- a/app/src/main/java/me/worric/souvenarius/ui/detail/EditDialog.java
+++ b/app/src/main/java/me/worric/souvenarius/ui/detail/EditDialog.java
@@ -52,7 +52,7 @@ public class EditDialog extends DialogFragment {
         super.onViewCreated(view, savedInstanceState);
         mTextType = (DetailFragment.TextType) getArguments().getSerializable(KEY_TEXT_TYPE);
         mViewModel = ViewModelProviders.of(getParentFragment(), mFactory).get(DetailViewModel.class);
-        mViewModel.getCurrentSouvenir().observe(this, souvenirDb -> {
+        mViewModel.getCurrentSouvenir().observe(getViewLifecycleOwner(), souvenirDb -> {
             mBinding.setCurrentSouvenir(souvenirDb);
             restoreScrollPosition(savedInstanceState);
         });


### PR DESCRIPTION
This PR updates relevant `Fragment`s to use the LifecycleOwner of the View (via the recently added `getViewLifecycleOwner()`) in order to prevent potential issues with registering multiple observers with a given `LiveData`. This PR is more of a consistency related change, as the as of yet only known bug of this kind has already been fixed (#8).