### PR TITLE
Update Gradle wrapper to fetch Gradle v4.10.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
This PR updates Gradle to v4.10.1 (latest as of this time).

**NOTE:** "Configure on demand" must be disabled in order to use the new version of Gradle. Gradle cause an error as long as the feature is enabled. To disable it, go to `File -> Settings... -> Build, Execution, Deployment -> Compiler` and untick "Configure on demand"