### PR TITLE
Add MainActivity UI tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     androidTestImplementation "com.android.support.test:runner:$espressoRunnerVersion"
     androidTestImplementation "com.android.support.test:rules:$espressoRulesVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
+    androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/androidTest/java/me/worric/souvenarius/ui/main/MainActivityTest.java
+++ b/app/src/androidTest/java/me/worric/souvenarius/ui/main/MainActivityTest.java
@@ -16,19 +16,13 @@ import static android.support.test.espresso.matcher.ViewMatchers.*;
 @RunWith(AndroidJUnit4.class)
 public class MainActivityTest {
 
-    private static final String DUMMY_TEXT = "This is the message";
-
     @Rule
     public final ActivityTestRule<MainActivity> mTestRule = new ActivityTestRule<>(MainActivity.class);
 
     @Test
-    public void onStartup_DummyTextIsDisplayed() {
-        onView(withId(R.id.tv_hello_world)).check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void onStartup_DummyTextHasCorrectValue() {
-        onView(withId(R.id.tv_hello_world)).check(matches(withText(DUMMY_TEXT)));
+    public void onStartup_SouvenirsListIsDisplayed() {
+        onView(withId(R.id.rv_souvenir_list))
+                .check(matches(isDisplayed()));
     }
 
 }

--- a/app/src/androidTest/java/me/worric/souvenarius/ui/main/MainActivityTest.java
+++ b/app/src/androidTest/java/me/worric/souvenarius/ui/main/MainActivityTest.java
@@ -12,6 +12,7 @@ import me.worric.souvenarius.R;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
 import static android.support.test.espresso.matcher.ViewMatchers.*;
 
 @RunWith(AndroidJUnit4.class)
@@ -34,6 +35,17 @@ public class MainActivityTest {
         onView(withId(R.id.cv_add_container))
                 .check(matches(isDisplayed()));
         onView(withId(R.id.btn_add_save_souvenir))
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void onListItemClick_detailsFragmentIsDisplayed() {
+        onView(withId(R.id.rv_souvenir_list))
+                .perform(actionOnItemAtPosition(0, click()));
+
+        onView(withId(R.id.sv_detail_root))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.rv_souvenir_photo_list))
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/androidTest/java/me/worric/souvenarius/ui/main/MainActivityTest.java
+++ b/app/src/androidTest/java/me/worric/souvenarius/ui/main/MainActivityTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import me.worric.souvenarius.R;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.*;
 
@@ -22,6 +23,17 @@ public class MainActivityTest {
     @Test
     public void onStartup_SouvenirsListIsDisplayed() {
         onView(withId(R.id.rv_souvenir_list))
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void onFabClick_addFragmentIsDisplayed() {
+        onView(withId(R.id.btn_fab_add_souvenir))
+                .perform(click());
+
+        onView(withId(R.id.cv_add_container))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.btn_add_save_souvenir))
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -51,8 +51,6 @@
             app:layout_anchor="@+id/fragment_container"
             app:layout_anchorGravity="bottom|end"
             android:contentDescription="@string/content_desc_main_add_souvenir"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
             android:src="@drawable/ic_add_a_photo"
             android:onClick="handleAddFabClicked" />
 

--- a/app/src/main/res/layout/item_main_souvenir.xml
+++ b/app/src/main/res/layout/item_main_souvenir.xml
@@ -15,9 +15,7 @@
         android:layout_margin="4dp"
         app:cardCornerRadius="@dimen/card_corner_radius"
         app:cardElevation="@dimen/card_elevation"
-        android:onClick="@{() -> clickListener.onSouvenirClicked(souvenir)}"
-        android:clickable="true"
-        android:focusable="true">
+        android:onClick="@{() -> clickListener.onSouvenirClicked(souvenir)}">
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
This PR adds a few UI tests to check for both for a correct launch as well as basic navigation.

Furthermore, it fixes 2 bugs that caused the user to have to click twice on both the FAB and a `RecyclerView` item, in order to trigger their respective action.